### PR TITLE
chore(sample): modernize sample app

### DIFF
--- a/SMPPaymentSampleApp.xcodeproj/project.pbxproj
+++ b/SMPPaymentSampleApp.xcodeproj/project.pbxproj
@@ -24,6 +24,7 @@
 		E97A96F216413A4D00C9EC7C /* Default-568h@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = E97A96F116413A4D00C9EC7C /* Default-568h@2x.png */; };
 		E97A96F516413A4D00C9EC7C /* SMPPaymentViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = E97A96F416413A4D00C9EC7C /* SMPPaymentViewController.m */; };
 		E97A96F816413A4D00C9EC7C /* SMPPaymentViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = E97A96F616413A4D00C9EC7C /* SMPPaymentViewController.xib */; };
+		F000000116413A4D00C9EC7C /* SMPPaymentSceneDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = F000000316413A4D00C9EC7C /* SMPPaymentSceneDelegate.m */; };
 		E9C5F0EC1B988E9900EE5AA2 /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E9C5F0EB1B988E9900EE5AA2 /* UIKit.framework */; };
 /* End PBXBuildFile section */
 
@@ -50,6 +51,8 @@
 		E97A96F316413A4D00C9EC7C /* SMPPaymentViewController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SMPPaymentViewController.h; sourceTree = "<group>"; };
 		E97A96F416413A4D00C9EC7C /* SMPPaymentViewController.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SMPPaymentViewController.m; sourceTree = "<group>"; };
 		E97A96F716413A4D00C9EC7C /* en */ = {isa = PBXFileReference; lastKnownFileType = file.xib; name = en; path = en.lproj/SMPPaymentViewController.xib; sourceTree = "<group>"; };
+		F000000216413A4D00C9EC7C /* SMPPaymentSceneDelegate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SMPPaymentSceneDelegate.h; sourceTree = "<group>"; };
+		F000000316413A4D00C9EC7C /* SMPPaymentSceneDelegate.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SMPPaymentSceneDelegate.m; sourceTree = "<group>"; };
 		E9C5F0EB1B988E9900EE5AA2 /* UIKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = UIKit.framework; path = System/Library/Frameworks/UIKit.framework; sourceTree = SDKROOT; };
 /* End PBXFileReference section */
 
@@ -113,6 +116,8 @@
 			children = (
 				E97A96EA16413A4D00C9EC7C /* SMPPaymentAppDelegate.h */,
 				E97A96EB16413A4D00C9EC7C /* SMPPaymentAppDelegate.m */,
+				F000000216413A4D00C9EC7C /* SMPPaymentSceneDelegate.h */,
+				F000000316413A4D00C9EC7C /* SMPPaymentSceneDelegate.m */,
 				E97A96F316413A4D00C9EC7C /* SMPPaymentViewController.h */,
 				E97A96F416413A4D00C9EC7C /* SMPPaymentViewController.m */,
 				E97A96F616413A4D00C9EC7C /* SMPPaymentViewController.xib */,
@@ -213,6 +218,7 @@
 			files = (
 				E97A96E816413A4D00C9EC7C /* main.m in Sources */,
 				E97A96EC16413A4D00C9EC7C /* SMPPaymentAppDelegate.m in Sources */,
+				F000000116413A4D00C9EC7C /* SMPPaymentSceneDelegate.m in Sources */,
 				E97A96F516413A4D00C9EC7C /* SMPPaymentViewController.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -257,7 +263,7 @@
 				GCC_WARN_ABOUT_RETURN_TYPE = YES;
 				GCC_WARN_UNINITIALIZED_AUTOS = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 6.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -276,7 +282,7 @@
 				GCC_WARN_ABOUT_RETURN_TYPE = YES;
 				GCC_WARN_UNINITIALIZED_AUTOS = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 6.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				OTHER_CFLAGS = "-DNS_BLOCK_ASSERTIONS=1";
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -289,6 +295,7 @@
 			buildSettings = {
 				DEVELOPMENT_TEAM = "";
 				ENABLE_BITCODE = NO;
+				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = arm64;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"\"$(SRCROOT)/\"",
@@ -296,7 +303,7 @@
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "SMPPaymentSampleApp/SMPPaymentSampleApp-Prefix.pch";
 				INFOPLIST_FILE = "SMPPaymentSampleApp/SMPPaymentSampleApp-Info.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 6.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				LIBRARY_SEARCH_PATHS = "";
 				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.sumup.${PRODUCT_NAME:rfc1034identifier}";
@@ -311,6 +318,7 @@
 			buildSettings = {
 				DEVELOPMENT_TEAM = "";
 				ENABLE_BITCODE = NO;
+				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = arm64;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"\"$(SRCROOT)/\"",
@@ -318,7 +326,7 @@
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "SMPPaymentSampleApp/SMPPaymentSampleApp-Prefix.pch";
 				INFOPLIST_FILE = "SMPPaymentSampleApp/SMPPaymentSampleApp-Info.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 6.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				LIBRARY_SEARCH_PATHS = "";
 				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.sumup.${PRODUCT_NAME:rfc1034identifier}";

--- a/SMPPaymentSampleApp/SMPPaymentAppDelegate.h
+++ b/SMPPaymentSampleApp/SMPPaymentAppDelegate.h
@@ -8,12 +8,5 @@
 
 #import <UIKit/UIKit.h>
 
-@class SMPPaymentViewController;
-
 @interface SMPPaymentAppDelegate : UIResponder <UIApplicationDelegate>
-
-@property(strong, nonatomic) UIWindow* window;
-
-@property(strong, nonatomic) SMPPaymentViewController* viewController;
-
 @end

--- a/SMPPaymentSampleApp/SMPPaymentAppDelegate.m
+++ b/SMPPaymentSampleApp/SMPPaymentAppDelegate.m
@@ -7,77 +7,21 @@
 //
 
 #import "SMPPaymentAppDelegate.h"
-#import "SMPPaymentViewController.h"
-#import <SMPPayment/SMPPaymentRequest.h>
 
 @implementation SMPPaymentAppDelegate
 
 - (BOOL)application:(UIApplication*)application
     didFinishLaunchingWithOptions:(NSDictionary*)launchOptions
 {
-    self.window = [[UIWindow alloc] initWithFrame:[[UIScreen mainScreen] bounds]];
-    self.viewController =
-        [[SMPPaymentViewController alloc] initWithNibName:@"SMPPaymentViewController" bundle:nil];
-
-    self.window.rootViewController = self.viewController;
-    [self.window makeKeyAndVisible];
     return YES;
 }
 
-- (BOOL)handleSumUpCallbackURL:(NSURL*)url sourceApplication:(NSString*)sourceApplication
+- (UISceneConfiguration*)application:(UIApplication*)application
+configurationForConnectingSceneSession:(UISceneSession*)connectingSceneSession
+                              options:(UISceneConnectionOptions*)options API_AVAILABLE(ios(13.0))
 {
-    if (sourceApplication.length && ![sourceApplication hasPrefix:@"com.sumup.merchant"])
-    {
-        NSLog(@"Not SumUp merchant app.");
-        return YES;
-    }
-
-    NSString* status;
-    NSString* txCode;
-
-    for (NSURLQueryItem* queryItem in [[NSURLComponents alloc] initWithURL:url
-                                                   resolvingAgainstBaseURL:NO]
-             .queryItems)
-    {
-        if ([queryItem.name isEqualToString:(NSString*)SMPPaymentRequestKeyStatus])
-        {
-            status = queryItem.value;
-        }
-        else if ([queryItem.name isEqualToString:(NSString*)SMPPaymentRequestKeyTransactionCode])
-        {
-            txCode = queryItem.value;
-        }
-    }
-
-    NSString* alertMessage;
-
-    if ([status isEqualToString:(NSString*)SMPPaymentRequestStatusSuccess])
-    {
-        alertMessage = [NSString stringWithFormat:@"Thanks. Payment successful. Code: %@.", txCode];
-    }
-    else
-    {
-        alertMessage = [NSString
-            stringWithFormat:@"Payment failed with status and code: %@ - %@", status, txCode];
-    }
-
-    NSLog(@"status - code: %@ - %@", status, txCode);
-
-    [[[UIAlertView alloc] initWithTitle:status
-                                message:alertMessage
-                               delegate:nil
-                      cancelButtonTitle:@"OK"
-                      otherButtonTitles:nil] show];
-
-    return YES;
-}
-
-- (BOOL)application:(UIApplication*)application
-            openURL:(NSURL*)url
-            options:(NSDictionary<UIApplicationOpenURLOptionsKey, id>*)options
-{
-    return [self handleSumUpCallbackURL:url
-                      sourceApplication:options[UIApplicationOpenURLOptionsSourceApplicationKey]];
+    return [[UISceneConfiguration alloc] initWithName:@"Default Configuration"
+                                          sessionRole:connectingSceneSession.role];
 }
 
 @end

--- a/SMPPaymentSampleApp/SMPPaymentAppDelegate.m
+++ b/SMPPaymentSampleApp/SMPPaymentAppDelegate.m
@@ -17,8 +17,9 @@
 }
 
 - (UISceneConfiguration*)application:(UIApplication*)application
-configurationForConnectingSceneSession:(UISceneSession*)connectingSceneSession
-                              options:(UISceneConnectionOptions*)options API_AVAILABLE(ios(13.0))
+    configurationForConnectingSceneSession:(UISceneSession*)connectingSceneSession
+                                   options:(UISceneConnectionOptions*)options
+    API_AVAILABLE(ios(13.0))
 {
     return [[UISceneConfiguration alloc] initWithName:@"Default Configuration"
                                           sessionRole:connectingSceneSession.role];

--- a/SMPPaymentSampleApp/SMPPaymentSampleApp-Info.plist
+++ b/SMPPaymentSampleApp/SMPPaymentSampleApp-Info.plist
@@ -50,10 +50,23 @@
 	<true/>
 	<key>UIPrerenderedIcon</key>
 	<true/>
-	<key>UIRequiredDeviceCapabilities</key>
-	<array>
-		<string>armv7</string>
-	</array>
+	<key>UIApplicationSceneManifest</key>
+	<dict>
+		<key>UIApplicationSupportsMultipleScenes</key>
+		<false/>
+		<key>UISceneConfigurations</key>
+		<dict>
+			<key>UIWindowSceneSessionRoleApplication</key>
+			<array>
+				<dict>
+					<key>UISceneConfigurationName</key>
+					<string>Default Configuration</string>
+					<key>UISceneDelegateClassName</key>
+					<string>$(PRODUCT_MODULE_NAME).SMPPaymentSceneDelegate</string>
+				</dict>
+			</array>
+		</dict>
+	</dict>
 	<key>UISupportedInterfaceOrientations</key>
 	<array>
 		<string>UIInterfaceOrientationPortrait</string>

--- a/SMPPaymentSampleApp/SMPPaymentSceneDelegate.h
+++ b/SMPPaymentSampleApp/SMPPaymentSceneDelegate.h
@@ -1,0 +1,14 @@
+//
+//  SMPPaymentSceneDelegate.h
+//  SMPPaymentSampleApp
+//
+//  Created by OpenAI Codex on 03/17/26.
+//
+
+#import <UIKit/UIKit.h>
+
+@interface SMPPaymentSceneDelegate : UIResponder <UIWindowSceneDelegate>
+
+@property (strong, nonatomic) UIWindow *window;
+
+@end

--- a/SMPPaymentSampleApp/SMPPaymentSceneDelegate.h
+++ b/SMPPaymentSampleApp/SMPPaymentSceneDelegate.h
@@ -9,6 +9,6 @@
 
 @interface SMPPaymentSceneDelegate : UIResponder <UIWindowSceneDelegate>
 
-@property (strong, nonatomic) UIWindow *window;
+@property(strong, nonatomic) UIWindow* window;
 
 @end

--- a/SMPPaymentSampleApp/SMPPaymentSceneDelegate.m
+++ b/SMPPaymentSampleApp/SMPPaymentSceneDelegate.m
@@ -1,0 +1,43 @@
+//
+//  SMPPaymentSceneDelegate.m
+//  SMPPaymentSampleApp
+//
+//  Created by OpenAI Codex on 03/17/26.
+//
+
+#import "SMPPaymentSceneDelegate.h"
+#import "SMPPaymentViewController.h"
+
+@implementation SMPPaymentSceneDelegate
+
+- (void)scene:(UIScene *)scene willConnectToSession:(UISceneSession *)session options:(UISceneConnectionOptions *)connectionOptions API_AVAILABLE(ios(13.0)) {
+    if (![scene isKindOfClass:[UIWindowScene class]]) {
+        return;
+    }
+
+    UIWindowScene *windowScene = (UIWindowScene *)scene;
+    self.window = [[UIWindow alloc] initWithWindowScene:windowScene];
+    self.window.rootViewController = [[SMPPaymentViewController alloc] initWithNibName:@"SMPPaymentViewController" bundle:nil];
+    [self.window makeKeyAndVisible];
+
+    for (UIOpenURLContext *urlContext in connectionOptions.URLContexts) {
+        [self handleURLContext:urlContext];
+    }
+}
+
+- (void)scene:(UIScene *)scene openURLContexts:(NSSet<UIOpenURLContext *> *)URLContexts API_AVAILABLE(ios(13.0)) {
+    for (UIOpenURLContext *urlContext in URLContexts) {
+        [self handleURLContext:urlContext];
+    }
+}
+
+- (void)handleURLContext:(UIOpenURLContext *)urlContext API_AVAILABLE(ios(13.0)) {
+    if (![self.window.rootViewController isKindOfClass:[SMPPaymentViewController class]]) {
+        return;
+    }
+
+    SMPPaymentViewController *viewController = (SMPPaymentViewController *)self.window.rootViewController;
+    [viewController handleSumUpCallbackURL:urlContext.URL sourceApplication:urlContext.options.sourceApplication];
+}
+
+@end

--- a/SMPPaymentSampleApp/SMPPaymentSceneDelegate.m
+++ b/SMPPaymentSampleApp/SMPPaymentSceneDelegate.m
@@ -10,34 +10,47 @@
 
 @implementation SMPPaymentSceneDelegate
 
-- (void)scene:(UIScene *)scene willConnectToSession:(UISceneSession *)session options:(UISceneConnectionOptions *)connectionOptions API_AVAILABLE(ios(13.0)) {
-    if (![scene isKindOfClass:[UIWindowScene class]]) {
+- (void)scene:(UIScene*)scene
+    willConnectToSession:(UISceneSession*)session
+                 options:(UISceneConnectionOptions*)connectionOptions API_AVAILABLE(ios(13.0))
+{
+    if (![scene isKindOfClass:[UIWindowScene class]])
+    {
         return;
     }
 
-    UIWindowScene *windowScene = (UIWindowScene *)scene;
+    UIWindowScene* windowScene = (UIWindowScene*)scene;
     self.window = [[UIWindow alloc] initWithWindowScene:windowScene];
-    self.window.rootViewController = [[SMPPaymentViewController alloc] initWithNibName:@"SMPPaymentViewController" bundle:nil];
+    self.window.rootViewController =
+        [[SMPPaymentViewController alloc] initWithNibName:@"SMPPaymentViewController" bundle:nil];
     [self.window makeKeyAndVisible];
 
-    for (UIOpenURLContext *urlContext in connectionOptions.URLContexts) {
+    for (UIOpenURLContext* urlContext in connectionOptions.URLContexts)
+    {
         [self handleURLContext:urlContext];
     }
 }
 
-- (void)scene:(UIScene *)scene openURLContexts:(NSSet<UIOpenURLContext *> *)URLContexts API_AVAILABLE(ios(13.0)) {
-    for (UIOpenURLContext *urlContext in URLContexts) {
+- (void)scene:(UIScene*)scene
+    openURLContexts:(NSSet<UIOpenURLContext*>*)URLContexts API_AVAILABLE(ios(13.0))
+{
+    for (UIOpenURLContext* urlContext in URLContexts)
+    {
         [self handleURLContext:urlContext];
     }
 }
 
-- (void)handleURLContext:(UIOpenURLContext *)urlContext API_AVAILABLE(ios(13.0)) {
-    if (![self.window.rootViewController isKindOfClass:[SMPPaymentViewController class]]) {
+- (void)handleURLContext:(UIOpenURLContext*)urlContext API_AVAILABLE(ios(13.0))
+{
+    if (![self.window.rootViewController isKindOfClass:[SMPPaymentViewController class]])
+    {
         return;
     }
 
-    SMPPaymentViewController *viewController = (SMPPaymentViewController *)self.window.rootViewController;
-    [viewController handleSumUpCallbackURL:urlContext.URL sourceApplication:urlContext.options.sourceApplication];
+    SMPPaymentViewController* viewController =
+        (SMPPaymentViewController*)self.window.rootViewController;
+    [viewController handleSumUpCallbackURL:urlContext.URL
+                         sourceApplication:urlContext.options.sourceApplication];
 }
 
 @end

--- a/SMPPaymentSampleApp/SMPPaymentViewController.h
+++ b/SMPPaymentSampleApp/SMPPaymentViewController.h
@@ -17,6 +17,6 @@
 @property(weak, nonatomic) IBOutlet UITextView* textView;
 
 - (IBAction)payFromSender:(id)sender;
-- (void)handleSumUpCallbackURL:(NSURL *)url sourceApplication:(NSString *)sourceApplication;
+- (void)handleSumUpCallbackURL:(NSURL*)url sourceApplication:(NSString*)sourceApplication;
 
 @end

--- a/SMPPaymentSampleApp/SMPPaymentViewController.h
+++ b/SMPPaymentSampleApp/SMPPaymentViewController.h
@@ -17,5 +17,6 @@
 @property(weak, nonatomic) IBOutlet UITextView* textView;
 
 - (IBAction)payFromSender:(id)sender;
+- (void)handleSumUpCallbackURL:(NSURL *)url sourceApplication:(NSString *)sourceApplication;
 
 @end

--- a/SMPPaymentSampleApp/SMPPaymentViewController.m
+++ b/SMPPaymentSampleApp/SMPPaymentViewController.m
@@ -25,7 +25,8 @@
     NSString* txCode;
 
     for (NSURLQueryItem* queryItem in [[NSURLComponents alloc] initWithURL:url
-                                                 resolvingAgainstBaseURL:NO].queryItems)
+                                                   resolvingAgainstBaseURL:NO]
+             .queryItems)
     {
         if ([queryItem.name isEqualToString:(NSString*)SMPPaymentRequestKeyStatus])
         {
@@ -52,10 +53,10 @@
 
     NSLog(@"status - code: %@ - %@", status, txCode);
 
-    UIAlertController* alertController = [UIAlertController alertControllerWithTitle:alertTitle
-                                                                             message:alertMessage
-                                                                      preferredStyle:
-                                                                          UIAlertControllerStyleAlert];
+    UIAlertController* alertController =
+        [UIAlertController alertControllerWithTitle:alertTitle
+                                            message:alertMessage
+                                     preferredStyle:UIAlertControllerStyleAlert];
     [alertController addAction:[UIAlertAction actionWithTitle:@"OK"
                                                         style:UIAlertActionStyleDefault
                                                       handler:nil]];

--- a/SMPPaymentSampleApp/SMPPaymentViewController.m
+++ b/SMPPaymentSampleApp/SMPPaymentViewController.m
@@ -13,6 +13,55 @@
 
 @implementation SMPPaymentViewController
 
+- (void)handleSumUpCallbackURL:(NSURL*)url sourceApplication:(NSString*)sourceApplication
+{
+    if (sourceApplication.length && ![sourceApplication hasPrefix:@"com.sumup.merchant"])
+    {
+        NSLog(@"Not SumUp merchant app.");
+        return;
+    }
+
+    NSString* status;
+    NSString* txCode;
+
+    for (NSURLQueryItem* queryItem in [[NSURLComponents alloc] initWithURL:url
+                                                 resolvingAgainstBaseURL:NO].queryItems)
+    {
+        if ([queryItem.name isEqualToString:(NSString*)SMPPaymentRequestKeyStatus])
+        {
+            status = queryItem.value;
+        }
+        else if ([queryItem.name isEqualToString:(NSString*)SMPPaymentRequestKeyTransactionCode])
+        {
+            txCode = queryItem.value;
+        }
+    }
+
+    NSString* alertTitle = status ?: @"Callback received";
+    NSString* alertMessage;
+
+    if ([status isEqualToString:(NSString*)SMPPaymentRequestStatusSuccess])
+    {
+        alertMessage = [NSString stringWithFormat:@"Thanks. Payment successful. Code: %@.", txCode];
+    }
+    else
+    {
+        alertMessage = [NSString
+            stringWithFormat:@"Payment failed with status and code: %@ - %@", status, txCode];
+    }
+
+    NSLog(@"status - code: %@ - %@", status, txCode);
+
+    UIAlertController* alertController = [UIAlertController alertControllerWithTitle:alertTitle
+                                                                             message:alertMessage
+                                                                      preferredStyle:
+                                                                          UIAlertControllerStyleAlert];
+    [alertController addAction:[UIAlertAction actionWithTitle:@"OK"
+                                                        style:UIAlertActionStyleDefault
+                                                      handler:nil]];
+    [self presentViewController:alertController animated:YES completion:nil];
+}
+
 - (void)viewDidAppear:(BOOL)animated
 {
     [super viewDidAppear:animated];


### PR DESCRIPTION
[fix(sample): parse SumUp callback transaction codes correctly](https://github.com/sumup/sumup-ios-url-scheme/commit/9042cf17a98a6e6836fbc4bd18411d341104e409)

Use NSURLComponents for callback parsing, keep the legacy openURL entrypoint, and add the modern openURL:options: path so the sample app demonstrates current callback handling without changing the integration contract.

[chore(sample): modernize the sample app lifecycle](https://github.com/sumup/sumup-ios-url-scheme/commit/3d98685b0ed3912bf1b3268ae922cdd59ccc2135)

Raise the sample app deployment target, move it to a scene-based lifecycle, replace UIAlertView with UIAlertController, and keep the callback flow working with current iOS entrypoints. Exclude arm64 simulator builds as a temporary workaround for the legacy vendored framework slice layout.