### PR TITLE
chore(format): add Objective-C formatting checks

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,8 @@
+---
+BasedOnStyle: LLVM
+IndentWidth: 4
+ColumnLimit: 100
+BreakBeforeBraces: Allman
+PointerAlignment: Left
+SortIncludes: false
+...

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,14 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.md]
+trim_trailing_whitespace = false
+
+[*.{h,m}]
+indent_style = space
+indent_size = 4

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,19 @@
+name: Lint
+
+on:
+  push:
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  lint:
+    runs-on: macos-15-intel
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Check Objective-C formatting
+        run: bash scripts/check-format.sh

--- a/README.md
+++ b/README.md
@@ -17,7 +17,6 @@ If you are planning to open the SumUp app using a URL, please find the parameter
 |`currency`      | The ISO 4217 code of currency to be charged. The currency needs to match the currency of the user that is logged into the SumUp app. For example EUR, GBP, BRL, CHF, PLN. |
 |`affiliate-key` | Your affiliate key. It needs to be associated with the calling app's bundle identifier. |
 
-
 ## Optional query parameters
 
 | Key                 | Comment |
@@ -30,7 +29,6 @@ If you are planning to open the SumUp app using a URL, please find the parameter
 |`foreign-tx-id`      | An optional ID to be associated with this transaction. Please see our [API documentation](https://sumup.com/integration#transactionReportingAPIs) on how to retrieve a transaction using this ID. This ID has to be unique in the scope of a SumUp merchant account and its sub-accounts. It must not be longer than 128 characters and can only contain printable ASCII characters. *Supported by SumUp app version 1.53 and later. Version 1.53.2 and later will append it to the callback URLs as a [query parameter](#Callback-query-parameters) if provided.* |
 |`skip-screen-success`| To skip the screen shown at the end of a successful transaction, the `skip-screen-success=true` parameter can be used. When using the parameter  your application is responsible for displaying the transaction result to the customer. In combination with the Receipts API your application can also send your own receipts, see [API documentation](https://sumup.com/docs/rest-api/transactions-api) for details. Please note success screens will still be shown when using the SumUp Air Lite readers. *Supported by SumUp app version 1.69 and later.*|
 
-
 ## Callback query parameters
 
 After the payment has been executed the SumUp app will open the `callbacksuccess` URL if the payment succeeded and the `callbackfail` URL if it did not. We will append the following query parameters if applicable:
@@ -42,7 +40,6 @@ After the payment has been executed the SumUp app will open the `callbacksuccess
 |                 | invalidstate     | The transaction can not be accepted as the SumUp app is in an invalid state. Please ask the user to open the SumUp app and make sure he's ready to accept payments. |
 | `smp-tx-code`   | TRANSACTION-CODE | The transaction code for this payment. Please see our [API documentation](https://sumup.com/integration#transactionReportingAPIs) to find out how to retreive details on this payment. *Supported by SumUp app version 1.53 and later.* |
 | `foreign-tx-id` | YOUR-TX-ID       | Only if provided. See [Optional query parameters](#optional-query-parameters). *Supported by SumUp app version 1.53.2 and later.*|
-
 
 ## SMPPaymentRequest
 If you are building your own iOS app you can use this class to conveniently open the SumUp app to accept a payment. It knows about all the URL parameters and makes accepting a payment as easy as:
@@ -74,7 +71,6 @@ request = [SMPPaymentRequest paymentRequestWithAmount:amount
 
 [request openSumUpMerchantApp];
 ```
-
 
 ## Community
 

--- a/SMPPaymentSampleApp/SMPPaymentAppDelegate.h
+++ b/SMPPaymentSampleApp/SMPPaymentAppDelegate.h
@@ -12,8 +12,8 @@
 
 @interface SMPPaymentAppDelegate : UIResponder <UIApplicationDelegate>
 
-@property (strong, nonatomic) UIWindow *window;
+@property(strong, nonatomic) UIWindow* window;
 
-@property (strong, nonatomic) SMPPaymentViewController *viewController;
+@property(strong, nonatomic) SMPPaymentViewController* viewController;
 
 @end

--- a/SMPPaymentSampleApp/SMPPaymentAppDelegate.m
+++ b/SMPPaymentSampleApp/SMPPaymentAppDelegate.m
@@ -12,57 +12,77 @@
 
 @implementation SMPPaymentAppDelegate
 
-- (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions
+- (BOOL)application:(UIApplication*)application
+    didFinishLaunchingWithOptions:(NSDictionary*)launchOptions
 {
     self.window = [[UIWindow alloc] initWithFrame:[[UIScreen mainScreen] bounds]];
-    self.viewController = [[SMPPaymentViewController alloc] initWithNibName:@"SMPPaymentViewController" bundle:nil];
+    self.viewController =
+        [[SMPPaymentViewController alloc] initWithNibName:@"SMPPaymentViewController" bundle:nil];
 
     self.window.rootViewController = self.viewController;
     [self.window makeKeyAndVisible];
     return YES;
 }
 
-- (BOOL)application:(UIApplication *)application openURL:(NSURL *)url sourceApplication:(NSString *)sourceApplication annotation:(id)annotation {
-    if (![sourceApplication hasPrefix:@"com.sumup.merchant"]) {
+- (BOOL)application:(UIApplication*)application
+              openURL:(NSURL*)url
+    sourceApplication:(NSString*)sourceApplication
+           annotation:(id)annotation
+{
+    if (![sourceApplication hasPrefix:@"com.sumup.merchant"])
+    {
         NSLog(@"Not SumUp merchant app.");
         return YES;
     }
-    
+
     // Get status and transaction code from URL query when being opened from SumUp app.
-    NSArray *pairs = [[url query] componentsSeparatedByString:@"&"];
-    NSString *status;
-    NSString *txCode;
-    
-    for (NSString *kvp in pairs) {
-        NSArray *kv = [kvp componentsSeparatedByString:@"="];
-        
-        if ([kv count] != 2) {
+    NSArray* pairs = [[url query] componentsSeparatedByString:@"&"];
+    NSString* status;
+    NSString* txCode;
+
+    for (NSString* kvp in pairs)
+    {
+        NSArray* kv = [kvp componentsSeparatedByString:@"="];
+
+        if ([kv count] != 2)
+        {
             continue;
         }
-        
-        NSString *key = [kv[0] stringByReplacingPercentEscapesUsingEncoding:NSUTF8StringEncoding];
-        NSString *val = [kv[1] stringByReplacingPercentEscapesUsingEncoding:NSUTF8StringEncoding];
-        
-        if ([key isEqualToString:(NSString *)SMPPaymentRequestKeyStatus]) {
+
+        NSString* key = [kv[0] stringByReplacingPercentEscapesUsingEncoding:NSUTF8StringEncoding];
+        NSString* val = [kv[1] stringByReplacingPercentEscapesUsingEncoding:NSUTF8StringEncoding];
+
+        if ([key isEqualToString:(NSString*)SMPPaymentRequestKeyStatus])
+        {
             status = val;
-        } else if ([key isEqualToString:(NSString *)SMPPaymentRequestKeyTransactionCode]) {
+        }
+        else if ([key isEqualToString:(NSString*)SMPPaymentRequestKeyTransactionCode])
+        {
             txCode = key;
         }
     }
-    
-    NSString *alertMessage;
-    
+
+    NSString* alertMessage;
+
     // check if payment did succeed
-    if ([status isEqualToString:(NSString *)SMPPaymentRequestStatusSuccess]) {
+    if ([status isEqualToString:(NSString*)SMPPaymentRequestStatusSuccess])
+    {
         alertMessage = [NSString stringWithFormat:@"Thanks. Payment successful. Code: %@.", txCode];
-    } else {
-        alertMessage = [NSString stringWithFormat:@"Payment failed with status and code: %@ - %@", status, txCode];
     }
-    
+    else
+    {
+        alertMessage = [NSString
+            stringWithFormat:@"Payment failed with status and code: %@ - %@", status, txCode];
+    }
+
     NSLog(@"status - code: %@ - %@", status, txCode);
-    
-    [[[UIAlertView alloc] initWithTitle:status message:alertMessage delegate:nil cancelButtonTitle:@"OK" otherButtonTitles:nil] show];
-    
+
+    [[[UIAlertView alloc] initWithTitle:status
+                                message:alertMessage
+                               delegate:nil
+                      cancelButtonTitle:@"OK"
+                      otherButtonTitles:nil] show];
+
     return YES;
 }
 

--- a/SMPPaymentSampleApp/SMPPaymentViewController.h
+++ b/SMPPaymentSampleApp/SMPPaymentViewController.h
@@ -9,12 +9,12 @@
 #import <UIKit/UIKit.h>
 
 @interface SMPPaymentViewController : UIViewController <UITextFieldDelegate>
-@property (weak, nonatomic) IBOutlet UITextField *textFieldAmount;
-@property (weak, nonatomic) IBOutlet UITextField *textFieldCurrency;
-@property (weak, nonatomic) IBOutlet UITextField *textFieldTitle;
-@property (weak, nonatomic) IBOutlet UITextField *textFieldPhone;
-@property (weak, nonatomic) IBOutlet UITextField *textFieldEmail;
-@property (weak, nonatomic) IBOutlet UITextView *textView;
+@property(weak, nonatomic) IBOutlet UITextField* textFieldAmount;
+@property(weak, nonatomic) IBOutlet UITextField* textFieldCurrency;
+@property(weak, nonatomic) IBOutlet UITextField* textFieldTitle;
+@property(weak, nonatomic) IBOutlet UITextField* textFieldPhone;
+@property(weak, nonatomic) IBOutlet UITextField* textFieldEmail;
+@property(weak, nonatomic) IBOutlet UITextView* textView;
 
 - (IBAction)payFromSender:(id)sender;
 

--- a/SMPPaymentSampleApp/SMPPaymentViewController.m
+++ b/SMPPaymentSampleApp/SMPPaymentViewController.m
@@ -13,67 +13,86 @@
 
 @implementation SMPPaymentViewController
 
-- (void)viewDidAppear:(BOOL)animated {
+- (void)viewDidAppear:(BOOL)animated
+{
     [super viewDidAppear:animated];
-    
-    NSString *currency = [[NSUserDefaults standardUserDefaults] stringForKey:@"currency"];
-    
-    if (!currency.length) {
+
+    NSString* currency = [[NSUserDefaults standardUserDefaults] stringForKey:@"currency"];
+
+    if (!currency.length)
+    {
         currency = @"EUR";
     }
-    
+
     [self.textFieldCurrency setText:currency];
-    
+
     // verify that SumUp app is installed. If it's not ask user to install and open AppStore using
     // +[SMPPaymentRequest showSumUpMerchantInAppStore]
-    NSLog(@"SumUp app is installed: %@", [SMPPaymentRequest canOpenSumUpMerchantApp]?@"YES":@"NO");
+    NSLog(@"SumUp app is installed: %@",
+          [SMPPaymentRequest canOpenSumUpMerchantApp] ? @"YES" : @"NO");
 }
 
-- (IBAction)payFromSender:(id)sender {
-    [[NSUserDefaults standardUserDefaults] setObject:self.textFieldCurrency.text forKey:@"currency"];
-    
-    SMPPaymentRequest *request = [SMPPaymentRequest paymentRequestWithAmount:[self amountNumber] currency:self.textFieldCurrency.text title:self.textFieldTitle.text affiliateKey:AFFILIATE_KEY];
-    
+- (IBAction)payFromSender:(id)sender
+{
+    [[NSUserDefaults standardUserDefaults] setObject:self.textFieldCurrency.text
+                                              forKey:@"currency"];
+
+    SMPPaymentRequest* request =
+        [SMPPaymentRequest paymentRequestWithAmount:[self amountNumber]
+                                           currency:self.textFieldCurrency.text
+                                              title:self.textFieldTitle.text
+                                       affiliateKey:AFFILIATE_KEY];
+
     // This should match your app's URL scheme.
     // See "URL Types" in target's "Info" tab in project editor.
     [request setCallbackURLFailure:[NSURL URLWithString:@"samplepaymentapp://"]];
     [request setCallbackURLSuccess:[NSURL URLWithString:@"samplepaymentapp://"]];
-    
+
     // optional parameters to be pre-filled when sending a receipt
     [request setReceiptPhoneNumber:self.textFieldPhone.text];
     [request setReceiptEmailAddress:self.textFieldEmail.text];
-    
+
     // The foreignTransactionID is an optional parameter and can be used
     // to retrieve a transaction from SumUp's API.
     // See -[SMPPaymentRequest foreignTransactionID]
-    [request setForeignTransactionID:[NSString stringWithFormat:@"your-unique-id-%@", [[NSProcessInfo processInfo] globallyUniqueString]]];
-    
-    NSURL *launchURL = [request urlToLaunchSumupMerchantApp];
+    [request setForeignTransactionID:[NSString stringWithFormat:@"your-unique-id-%@",
+                                                                [[NSProcessInfo processInfo]
+                                                                    globallyUniqueString]]];
+
+    NSURL* launchURL = [request urlToLaunchSumupMerchantApp];
     NSLog(@"request: %@ :%@", request, launchURL);
-    
-    if (!launchURL) {
+
+    if (!launchURL)
+    {
         [self.textView setText:@"Failed to create URL. Missing mandatory parameters?"];
         return;
     }
-    
+
     [self.textView setText:[launchURL absoluteString]];
-    
-    if (![request openSumUpMerchantApp]) {
-        [self.textView setText:[self.textView.text stringByAppendingFormat:@"\nNo app installed to handle URL!"]];
+
+    if (![request openSumUpMerchantApp])
+    {
+        [self.textView setText:[self.textView.text
+                                   stringByAppendingFormat:@"\nNo app installed to handle URL!"]];
     }
 }
 
-- (NSDecimalNumber *)amountNumber {
-    if (![self.textFieldAmount.text length]) {
+- (NSDecimalNumber*)amountNumber
+{
+    if (![self.textFieldAmount.text length])
+    {
         return [NSDecimalNumber zero];
     }
-    
-    NSString *decSep = [[NSLocale currentLocale] objectForKey:NSLocaleDecimalSeparator];
-    
-    return [NSDecimalNumber decimalNumberWithString:[self.textFieldAmount.text stringByReplacingOccurrencesOfString:decSep withString:@"."]];
+
+    NSString* decSep = [[NSLocale currentLocale] objectForKey:NSLocaleDecimalSeparator];
+
+    return [NSDecimalNumber decimalNumberWithString:[self.textFieldAmount.text
+                                                        stringByReplacingOccurrencesOfString:decSep
+                                                                                  withString:@"."]];
 }
 
-- (BOOL)textFieldShouldReturn:(UITextField *)textField {
+- (BOOL)textFieldShouldReturn:(UITextField*)textField
+{
     [textField resignFirstResponder];
     return YES;
 }

--- a/SMPPaymentSampleApp/main.m
+++ b/SMPPaymentSampleApp/main.m
@@ -10,9 +10,10 @@
 
 #import "SMPPaymentAppDelegate.h"
 
-int main(int argc, char *argv[])
+int main(int argc, char* argv[])
 {
-    @autoreleasepool {
+    @autoreleasepool
+    {
         return UIApplicationMain(argc, argv, nil, NSStringFromClass([SMPPaymentAppDelegate class]));
     }
 }

--- a/scripts/check-format.sh
+++ b/scripts/check-format.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo_root="$(
+  cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." >/dev/null 2>&1
+  /bin/pwd -P
+)"
+
+cd "$repo_root"
+
+tmp_dir="$(mktemp -d /tmp/sumup-clang-format-check.XXXXXX)"
+trap 'rm -rf "$tmp_dir"' EXIT
+
+status=0
+
+while IFS= read -r file; do
+  tmp_file="$tmp_dir/$(basename "$file")"
+  xcrun clang-format "$file" >"$tmp_file"
+  if ! cmp -s "$file" "$tmp_file"; then
+    echo "Formatting mismatch: $file" >&2
+    status=1
+  fi
+done < <(git ls-files 'SMPPaymentSampleApp/*.h' 'SMPPaymentSampleApp/*.m')
+
+exit "$status"

--- a/scripts/format.sh
+++ b/scripts/format.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo_root="$(
+  cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." >/dev/null 2>&1
+  /bin/pwd -P
+)"
+
+cd "$repo_root"
+
+git ls-files 'SMPPaymentSampleApp/*.h' 'SMPPaymentSampleApp/*.m' \
+  | while IFS= read -r file; do
+      xcrun clang-format -i "$file"
+    done


### PR DESCRIPTION
Add clang-format configuration, local helper scripts, and a pinned GitHub Actions workflow to enforce formatting for the sample app sources. Format the Objective-C sample files and document the local formatting commands.