### PR TITLE
docs(readme): refresh the iOS integration guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,48 +1,48 @@
-# SumUp Custom URL Scheme
+<div align="center">
+
+# SumUp iOS URL Scheme
+
+[![Documentation](https://img.shields.io/badge/docs-docs.sumup.com-0A2540)](https://docs.sumup.com)
+[![CI Status](https://github.com/sumup/sumup-ios-url-scheme/actions/workflows/ci.yml/badge.svg)](https://github.com/sumup/sumup-ios-url-scheme/actions/workflows/ci.yml)
+[![License](https://img.shields.io/github/license/sumup/sumup-ios-url-scheme)](./LICENSE)
+[![Platform](https://img.shields.io/badge/platform-iOS-000000)](https://developer.apple.com/ios/)
+
+</div>
 
 This repository documents the lightweight SumUp app-switch integration for iOS.
 It lets your app hand off a payment request to the SumUp merchant app through a
 custom URL scheme and receive the result through your own callback URL.
 
-If you want to accept payments fully inside your app, use the
-[SumUp iOS SDK](https://github.com/sumup/sumup-ios-sdk) instead. This repository
-is specifically about the app-switch contract.
+Use it when you want to:
 
-## When To Use This Integration
+- start a SumUp card-present payment from a native iOS app
+- keep the integration surface very small
+- receive the payment result back through your own URL scheme
 
-Use the custom URL scheme when:
+The sample app in this repository can be used as a reference implementation for
+the integration contract. If you want to accept payments fully inside your app,
+use the [SumUp iOS SDK](https://github.com/sumup/sumup-ios-sdk) instead.
 
-- your app already has its own checkout flow and only needs to hand off the
-  card-present payment step to the SumUp merchant app
-- you want the smallest possible integration surface
-- your app can handle returning from an external app through a callback URL
+## Getting Started
 
-To get started, create a SumUp account and obtain an affiliate key in the
-[Developer section](https://me.sumup.com/developers).
-
-## iOS Integration Checklist
-
-Before opening the SumUp app from your iOS app:
-
-1. Register a callback URL scheme for your app in `CFBundleURLTypes`.
-2. Add `sumupmerchant` to `LSApplicationQueriesSchemes` so
+1. Create a SumUp account.
+2. Generate an affiliate key in
+   [me.sumup.com/developers](https://me.sumup.com/developers).
+3. Register a callback URL scheme for your app in `CFBundleURLTypes`.
+4. Add `sumupmerchant` to `LSApplicationQueriesSchemes` so
    `canOpenURL("sumupmerchant://")` works.
-3. Use a unique `foreign-tx-id` for reconciliation and idempotency whenever
-   possible.
-4. Handle both success and failure callbacks and treat missing callback fields as
-   optional for backward compatibility.
+5. Use a unique `foreign-tx-id` whenever possible for reconciliation and
+   idempotency.
 
-The sample app in this repository shows an Objective-C integration updated for a
-modern iOS app lifecycle.
+## URL Contract
 
-## Base URL
+The compatibility contract for existing integrators is the launch URL:
 
 `sumupmerchant://pay/1.0`
 
-This URL and the query parameter names below are the compatibility contract for
-existing integrators.
+and the query parameter and callback parameter names documented below.
 
-## Mandatory Query Parameters
+### Mandatory Query Parameters
 
 | Key | Comment |
 | --- | :--- |
@@ -50,7 +50,7 @@ existing integrators.
 | `currency` | ISO 4217 currency code. It must match the currency of the merchant logged into the SumUp app, for example `EUR`, `GBP`, `BRL`, `CHF`, `PLN`. |
 | `affiliate-key` | Your affiliate key. It must be associated with the calling app's bundle identifier. |
 
-## Optional Query Parameters
+### Optional Query Parameters
 
 | Key | Comment |
 | --- | :--- |
@@ -62,7 +62,7 @@ existing integrators.
 | `foreign-tx-id` | Optional ID associated with the transaction. It must be unique within the merchant account scope, no longer than 128 characters, and use printable ASCII characters only. Supported by SumUp app version 1.53 and later. Version 1.53.2 and later appends it to callback URLs when provided. |
 | `skip-screen-success` | Set `skip-screen-success=true` to skip the success screen after a successful payment. Your application becomes responsible for displaying the result to the customer. Supported by SumUp app version 1.69 and later. |
 
-## Callback Query Parameters
+### Callback Query Parameters
 
 After the payment completes, the SumUp app opens `callbacksuccess` for a
 successful payment or `callbackfail` otherwise. The following query parameters
@@ -76,7 +76,9 @@ may be appended:
 | `smp-tx-code` | `TRANSACTION-CODE` | Transaction code for the payment. Supported by SumUp app version 1.53 and later. |
 | `foreign-tx-id` | `YOUR-TX-ID` | Present only when it was provided in the payment request. Supported by SumUp app version 1.53.2 and later. |
 
-## Building The URL Directly
+## Integration Options
+
+### Build The URL Directly
 
 If you are not using the helper framework, construct the launch URL yourself.
 For example:
@@ -85,10 +87,10 @@ For example:
 sumupmerchant://pay/1.0?amount=10.00&currency=EUR&affiliate-key=YOUR-AFFILIATE-KEY&title=Coffee%20beans&callbacksuccess=samplepaymentapp%3A%2F%2F&callbackfail=samplepaymentapp%3A%2F%2F&foreign-tx-id=order-123
 ```
 
-## `SMPPaymentRequest`
+### Use `SMPPaymentRequest`
 
-If you are integrating from Objective-C, `SMPPaymentRequest` still provides a
-convenient wrapper around the URL contract.
+If you are integrating from Objective-C, `SMPPaymentRequest` provides a
+convenient wrapper around the same URL contract.
 
 ```objc
 SMPPaymentRequest *request;
@@ -109,7 +111,7 @@ request.skipScreenOptions = SMPSkipScreenOptionSuccess;
 [request openSumUpMerchantApp];
 ```
 
-## Modern Callback Handling Example
+## Handle The Callback
 
 On current iOS versions, handle the callback in your scene delegate or
 `application:openURL:options:` implementation. Parse query items with
@@ -140,5 +142,5 @@ func scene(_ scene: UIScene, openURLContexts urlContexts: Set<UIOpenURLContext>)
 
 ## Community
 
-- **Questions?** Contact the integration team at <a href="mailto:integration@sumup.com">integration@sumup.com</a>.
-- **Found a bug?** [Open an issue](https://github.com/sumup/sumup-ios-url-scheme/issues/new) with as much detail as possible.
+- Questions: contact [integration@sumup.com](mailto:integration@sumup.com)
+- Bugs: [open an issue](https://github.com/sumup/sumup-ios-url-scheme/issues/new)

--- a/README.md
+++ b/README.md
@@ -1,48 +1,94 @@
-# SumUp custom URL scheme
+# SumUp Custom URL Scheme
 
-Using the custom SumUp URL scheme you can accept card payments from your iOS app or website through the SumUp iOS app.
- To get started you will need to create a SumUp account and get an affiliate key in our [Developer section](https://me.sumup.com/developers).
+This repository documents the lightweight SumUp app-switch integration for iOS.
+It lets your app hand off a payment request to the SumUp merchant app through a
+custom URL scheme and receive the result through your own callback URL.
 
-If you are going to open the SumUp app from your own iOS app, [SMPPaymentRequest](#smppaymentrequest) is a convenient way to do so. See the sample app project for details and examples. You might also want to take a look at the [SumUp iOS SDK](https://github.com/sumup/sumup-ios-sdk) to accept payments within your app.  
-If you are planning to open the SumUp app using a URL, please find the parameters below.
+If you want to accept payments fully inside your app, use the
+[SumUp iOS SDK](https://github.com/sumup/sumup-ios-sdk) instead. This repository
+is specifically about the app-switch contract.
+
+## When To Use This Integration
+
+Use the custom URL scheme when:
+
+- your app already has its own checkout flow and only needs to hand off the
+  card-present payment step to the SumUp merchant app
+- you want the smallest possible integration surface
+- your app can handle returning from an external app through a callback URL
+
+To get started, create a SumUp account and obtain an affiliate key in the
+[Developer section](https://me.sumup.com/developers).
+
+## iOS Integration Checklist
+
+Before opening the SumUp app from your iOS app:
+
+1. Register a callback URL scheme for your app in `CFBundleURLTypes`.
+2. Add `sumupmerchant` to `LSApplicationQueriesSchemes` so
+   `canOpenURL("sumupmerchant://")` works.
+3. Use a unique `foreign-tx-id` for reconciliation and idempotency whenever
+   possible.
+4. Handle both success and failure callbacks and treat missing callback fields as
+   optional for backward compatibility.
+
+The sample app in this repository shows an Objective-C integration updated for a
+modern iOS app lifecycle.
 
 ## Base URL
+
 `sumupmerchant://pay/1.0`
 
-## Mandatory query parameters
+This URL and the query parameter names below are the compatibility contract for
+existing integrators.
 
-| Key            | Comment |
-| ---------------|:------- |
-|`amount`        | The amount to charge. Please use `.` as a decimal separator. |
-|`currency`      | The ISO 4217 code of currency to be charged. The currency needs to match the currency of the user that is logged into the SumUp app. For example EUR, GBP, BRL, CHF, PLN. |
-|`affiliate-key` | Your affiliate key. It needs to be associated with the calling app's bundle identifier. |
+## Mandatory Query Parameters
 
-## Optional query parameters
+| Key | Comment |
+| --- | :--- |
+| `amount` | The amount to charge. Use `.` as the decimal separator. |
+| `currency` | ISO 4217 currency code. It must match the currency of the merchant logged into the SumUp app, for example `EUR`, `GBP`, `BRL`, `CHF`, `PLN`. |
+| `affiliate-key` | Your affiliate key. It must be associated with the calling app's bundle identifier. |
 
-| Key                 | Comment |
-| --------------------|:------- |
-| `title`             | An optional title to be set on this transaction.|
-|`callbackfail`       | URL to be opened when the transaction fails. See [Callback query parameters](#Callback-query-parameters).|
-|`callbacksuccess`    | URL to be opened when the transaction succeeds. See [Callback query parameters](#Callback-query-parameters).|
-|`receipt-email`      | Prefills the email textfield when asking the customer whether he wants a receipts. |
-|`receipt-mobilephone`| Prefills the phone number textfield when asking the customer whether he wants a receipts. |
-|`foreign-tx-id`      | An optional ID to be associated with this transaction. Please see our [API documentation](https://sumup.com/integration#transactionReportingAPIs) on how to retrieve a transaction using this ID. This ID has to be unique in the scope of a SumUp merchant account and its sub-accounts. It must not be longer than 128 characters and can only contain printable ASCII characters. *Supported by SumUp app version 1.53 and later. Version 1.53.2 and later will append it to the callback URLs as a [query parameter](#Callback-query-parameters) if provided.* |
-|`skip-screen-success`| To skip the screen shown at the end of a successful transaction, the `skip-screen-success=true` parameter can be used. When using the parameter  your application is responsible for displaying the transaction result to the customer. In combination with the Receipts API your application can also send your own receipts, see [API documentation](https://sumup.com/docs/rest-api/transactions-api) for details. Please note success screens will still be shown when using the SumUp Air Lite readers. *Supported by SumUp app version 1.69 and later.*|
+## Optional Query Parameters
 
-## Callback query parameters
+| Key | Comment |
+| --- | :--- |
+| `title` | Optional title for the transaction. |
+| `callbackfail` | URL to open when the transaction fails. See [Callback query parameters](#callback-query-parameters). |
+| `callbacksuccess` | URL to open when the transaction succeeds. See [Callback query parameters](#callback-query-parameters). |
+| `receipt-email` | Prefills the email field when the customer is asked about a receipt. |
+| `receipt-mobilephone` | Prefills the phone field when the customer is asked about a receipt. |
+| `foreign-tx-id` | Optional ID associated with the transaction. It must be unique within the merchant account scope, no longer than 128 characters, and use printable ASCII characters only. Supported by SumUp app version 1.53 and later. Version 1.53.2 and later appends it to callback URLs when provided. |
+| `skip-screen-success` | Set `skip-screen-success=true` to skip the success screen after a successful payment. Your application becomes responsible for displaying the result to the customer. Supported by SumUp app version 1.69 and later. |
 
-After the payment has been executed the SumUp app will open the `callbacksuccess` URL if the payment succeeded and the `callbackfail` URL if it did not. We will append the following query parameters if applicable:
+## Callback Query Parameters
 
-| Key             | Possible values  | Comment                        |
-| --------------- |:----------------:| :----------------------------- |
-| `smp-status`    | success          | The transaction has succeeded. |
-|                 | failed           | The transaction has failed.    |
-|                 | invalidstate     | The transaction can not be accepted as the SumUp app is in an invalid state. Please ask the user to open the SumUp app and make sure he's ready to accept payments. |
-| `smp-tx-code`   | TRANSACTION-CODE | The transaction code for this payment. Please see our [API documentation](https://sumup.com/integration#transactionReportingAPIs) to find out how to retreive details on this payment. *Supported by SumUp app version 1.53 and later.* |
-| `foreign-tx-id` | YOUR-TX-ID       | Only if provided. See [Optional query parameters](#optional-query-parameters). *Supported by SumUp app version 1.53.2 and later.*|
+After the payment completes, the SumUp app opens `callbacksuccess` for a
+successful payment or `callbackfail` otherwise. The following query parameters
+may be appended:
 
-## SMPPaymentRequest
-If you are building your own iOS app you can use this class to conveniently open the SumUp app to accept a payment. It knows about all the URL parameters and makes accepting a payment as easy as:
+| Key | Possible values | Comment |
+| --- | :---: | :--- |
+| `smp-status` | `success` | The transaction succeeded. |
+|  | `failed` | The transaction failed. |
+|  | `invalidstate` | The SumUp app was not ready to accept a payment. Ask the merchant to open the SumUp app and make sure it is ready to accept payments. |
+| `smp-tx-code` | `TRANSACTION-CODE` | Transaction code for the payment. Supported by SumUp app version 1.53 and later. |
+| `foreign-tx-id` | `YOUR-TX-ID` | Present only when it was provided in the payment request. Supported by SumUp app version 1.53.2 and later. |
+
+## Building The URL Directly
+
+If you are not using the helper framework, construct the launch URL yourself.
+For example:
+
+```text
+sumupmerchant://pay/1.0?amount=10.00&currency=EUR&affiliate-key=YOUR-AFFILIATE-KEY&title=Coffee%20beans&callbacksuccess=samplepaymentapp%3A%2F%2F&callbackfail=samplepaymentapp%3A%2F%2F&foreign-tx-id=order-123
+```
+
+## `SMPPaymentRequest`
+
+If you are integrating from Objective-C, `SMPPaymentRequest` still provides a
+convenient wrapper around the URL contract.
 
 ```objc
 SMPPaymentRequest *request;
@@ -53,26 +99,46 @@ request = [SMPPaymentRequest paymentRequestWithAmount:amount
                                                 title:@"My title"
                                          affiliateKey:@"YOUR-AFFILIATE-KEY"];
 
-[request setCallbackURLSuccess:[NSURL URLWithString:@"samplepaymentapp://"]];
-[request setCallbackURLFailure:[NSURL URLWithString:@"samplepaymentapp://"]];
+request.callbackURLSuccess = [NSURL URLWithString:@"samplepaymentapp://"];
+request.callbackURLFailure = [NSURL URLWithString:@"samplepaymentapp://"];
+request.foreignTransactionID = @"order-123";
 
-/* This will open the following URL
- * sumupmerchant://pay/1.0?amount=10.00&currency=EUR&affiliate-key=YOUR-AFFILIATE-KEY
- * &title=My%20title
- * &callbackfail=samplepaymentapp%3A%2F%2F
- * &callbacksuccess=samplepaymentapp%3A%2F%2F
- */
-
-/* Optionally: Setting the option to skip success screens
- * to add skip-screen-success=true to the URL
- * Supported by SumUp app version 1.69 and later.
- * [request setSkipScreenOptions:SMPSkipScreenOptionSuccess];
- */
+// Optional: add skip-screen-success=true
+request.skipScreenOptions = SMPSkipScreenOptionSuccess;
 
 [request openSumUpMerchantApp];
 ```
 
+## Modern Callback Handling Example
+
+On current iOS versions, handle the callback in your scene delegate or
+`application:openURL:options:` implementation. Parse query items with
+`NSURLComponents` instead of manually splitting strings.
+
+```swift
+func scene(_ scene: UIScene, openURLContexts urlContexts: Set<UIOpenURLContext>) {
+    guard let context = urlContexts.first else { return }
+
+    let components = URLComponents(url: context.url, resolvingAgainstBaseURL: false)
+    let queryItems = components?.queryItems ?? []
+
+    let status = queryItems.first(where: { $0.name == "smp-status" })?.value
+    let txCode = queryItems.first(where: { $0.name == "smp-tx-code" })?.value
+
+    print("status:", status ?? "nil", "txCode:", txCode ?? "nil")
+}
+```
+
+## Compatibility Notes
+
+- Keep using `sumupmerchant://pay/1.0`. Existing integrators rely on that path.
+- Preserve the current query parameter and callback parameter names.
+- Do not assume all callback parameters are present on older SumUp app versions.
+- If you need richer in-app payment flows, migrate to the
+  [SumUp iOS SDK](https://github.com/sumup/sumup-ios-sdk) rather than extending
+  the URL contract.
+
 ## Community
 
-- **Questions?** Get in contact with our integration team by sending an email to <a href="mailto:integration@sumup.com">integration@sumup.com</a>.  
-- **Found a bug?** [Open an issue](https://github.com/sumup/sumup-ios-url-scheme/issues/new). Please provide as much information as possible.
+- **Questions?** Contact the integration team at <a href="mailto:integration@sumup.com">integration@sumup.com</a>.
+- **Found a bug?** [Open an issue](https://github.com/sumup/sumup-ios-url-scheme/issues/new) with as much detail as possible.

--- a/README.md
+++ b/README.md
@@ -33,35 +33,35 @@ The compatibility contract for existing integrators is the launch URL `sumupmerc
 
 ### Mandatory Query Parameters
 
-| Key | Comment |
-| --- | :--- |
-| `amount` | The amount to charge. Use `.` as the decimal separator. |
-| `currency` | ISO 4217 currency code. It must match the currency of the merchant logged into the SumUp app, for example `EUR`, `GBP`, `BRL`, `CHF`, `PLN`. |
-| `affiliate-key` | Your affiliate key. It must be associated with the calling app's bundle identifier. |
+| Key             | Comment                                                                                                                                        |
+|-----------------|:-----------------------------------------------------------------------------------------------------------------------------------------------|
+| `amount`        | The amount to charge. Use `.` as the decimal separator.                                                                                        |
+| `currency`      | ISO 4217 currency code. It must match the currency of the merchant logged into the SumUp app, for example `EUR`, `GBP`, `BRL`, `CHF`, `PLN`. |
+| `affiliate-key` | Your affiliate key. It must be associated with the calling app's bundle identifier.                                                        |
 
 ### Optional Query Parameters
 
-| Key | Comment |
-| --- | :--- |
-| `title` | Optional title for the transaction. |
-| `callbackfail` | URL to open when the transaction fails. See [Callback query parameters](#callback-query-parameters). |
-| `callbacksuccess` | URL to open when the transaction succeeds. See [Callback query parameters](#callback-query-parameters). |
-| `receipt-email` | Prefills the email field when the customer is asked about a receipt. |
-| `receipt-mobilephone` | Prefills the phone field when the customer is asked about a receipt. |
-| `foreign-tx-id` | Optional ID associated with the transaction. It must be unique within the merchant account scope, no longer than 128 characters, and use printable ASCII characters only. Supported by SumUp app version 1.53 and later. Version 1.53.2 and later appends it to callback URLs when provided. |
-| `skip-screen-success` | Set `skip-screen-success=true` to skip the success screen after a successful payment. Your application becomes responsible for displaying the result to the customer. Supported by SumUp app version 1.69 and later. |
+| Key                   | Comment                                                                                                                                                                                                                                                                       |
+|-----------------------|:------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `title`               | Optional title for the transaction.                                                                                                                                                                                                                                            |
+| `callbackfail`        | URL to open when the transaction fails. See [Callback query parameters](#callback-query-parameters).                                                                                                                                                                          |
+| `callbacksuccess`     | URL to open when the transaction succeeds. See [Callback query parameters](#callback-query-parameters).                                                                                                                                                               |
+| `receipt-email`       | Prefills the email field when the customer is asked about a receipt.                                                                                                                                                                                                          |
+| `receipt-mobilephone` | Prefills the phone field when the customer is asked about a receipt.                                                                                                                                                                                                  |
+| `foreign-tx-id`       | Optional ID associated with the transaction. It must be unique within the merchant account scope, no longer than 128 characters, and use printable ASCII characters only. Supported by SumUp app version 1.53 and later. Version 1.53.2 and later appends it to callback URLs when provided. |
+| `skip-screen-success` | Set `skip-screen-success=true` to skip the success screen after a successful payment. Your application becomes responsible for displaying the result to the customer. Supported by SumUp app version 1.69 and later.                                                       |
 
 ### Callback Query Parameters
 
 After the payment completes, the SumUp app opens `callbacksuccess` for a successful payment or `callbackfail` otherwise. The following query parameters may be appended:
 
-| Key | Possible values | Comment |
-| --- | :---: | :--- |
-| `smp-status` | `success` | The transaction succeeded. |
-|  | `failed` | The transaction failed. |
-|  | `invalidstate` | The SumUp app was not ready to accept a payment. Ask the merchant to open the SumUp app and make sure it is ready to accept payments. |
-| `smp-tx-code` | `TRANSACTION-CODE` | Transaction code for the payment. Supported by SumUp app version 1.53 and later. |
-| `foreign-tx-id` | `YOUR-TX-ID` | Present only when it was provided in the payment request. Supported by SumUp app version 1.53.2 and later. |
+| Key             | Possible values    | Comment                                                                                                                                 |
+|-----------------|:------------------:|:----------------------------------------------------------------------------------------------------------------------------------------|
+| `smp-status`    | `success`          | The transaction succeeded.                                                                                                              |
+|                 | `failed`           | The transaction failed.                                                                                                                 |
+|                 | `invalidstate`     | The SumUp app was not ready to accept a payment. Ask the merchant to open the SumUp app and make sure it is ready to accept payments. |
+| `smp-tx-code`   | `TRANSACTION-CODE` | Transaction code for the payment. Supported by SumUp app version 1.53 and later.                                                            |
+| `foreign-tx-id` | `YOUR-TX-ID`       | Present only when it was provided in the payment request. Supported by SumUp app version 1.53.2 and later.                             |
 
 ## Integration Options
 

--- a/README.md
+++ b/README.md
@@ -9,9 +9,7 @@
 
 </div>
 
-This repository documents the lightweight SumUp app-switch integration for iOS.
-It lets your app hand off a payment request to the SumUp merchant app through a
-custom URL scheme and receive the result through your own callback URL.
+This repository documents the lightweight SumUp app-switch integration for iOS. It lets your app hand off a payment request to the SumUp merchant app through a custom URL scheme and receive the result through your own callback URL.
 
 Use it when you want to:
 
@@ -19,28 +17,19 @@ Use it when you want to:
 - keep the integration surface very small
 - receive the payment result back through your own URL scheme
 
-The sample app in this repository can be used as a reference implementation for
-the integration contract. If you want to accept payments fully inside your app,
-use the [SumUp iOS SDK](https://github.com/sumup/sumup-ios-sdk) instead.
+The sample app in this repository can be used as a reference implementation for the integration contract. If you want to accept payments fully inside your app, use the [SumUp iOS SDK](https://github.com/sumup/sumup-ios-sdk) instead.
 
 ## Getting Started
 
 1. Create a SumUp account.
-2. Generate an affiliate key in
-   [me.sumup.com/developers](https://me.sumup.com/developers).
+2. Generate an affiliate key in [me.sumup.com/developers](https://me.sumup.com/developers).
 3. Register a callback URL scheme for your app in `CFBundleURLTypes`.
-4. Add `sumupmerchant` to `LSApplicationQueriesSchemes` so
-   `canOpenURL("sumupmerchant://")` works.
-5. Use a unique `foreign-tx-id` whenever possible for reconciliation and
-   idempotency.
+4. Add `sumupmerchant` to `LSApplicationQueriesSchemes` so `canOpenURL("sumupmerchant://")` works.
+5. Use a unique `foreign-tx-id` whenever possible for reconciliation and idempotency.
 
 ## URL Contract
 
-The compatibility contract for existing integrators is the launch URL:
-
-`sumupmerchant://pay/1.0`
-
-and the query parameter and callback parameter names documented below.
+The compatibility contract for existing integrators is the launch URL `sumupmerchant://pay/1.0` and the query parameter and callback parameter names documented below.
 
 ### Mandatory Query Parameters
 
@@ -64,9 +53,7 @@ and the query parameter and callback parameter names documented below.
 
 ### Callback Query Parameters
 
-After the payment completes, the SumUp app opens `callbacksuccess` for a
-successful payment or `callbackfail` otherwise. The following query parameters
-may be appended:
+After the payment completes, the SumUp app opens `callbacksuccess` for a successful payment or `callbackfail` otherwise. The following query parameters may be appended:
 
 | Key | Possible values | Comment |
 | --- | :---: | :--- |
@@ -89,8 +76,7 @@ sumupmerchant://pay/1.0?amount=10.00&currency=EUR&affiliate-key=YOUR-AFFILIATE-K
 
 ### Use `SMPPaymentRequest`
 
-If you are integrating from Objective-C, `SMPPaymentRequest` provides a
-convenient wrapper around the same URL contract.
+If you are integrating from Objective-C, `SMPPaymentRequest` provides a convenient wrapper around the same URL contract.
 
 ```objc
 SMPPaymentRequest *request;
@@ -113,9 +99,7 @@ request.skipScreenOptions = SMPSkipScreenOptionSuccess;
 
 ## Handle The Callback
 
-On current iOS versions, handle the callback in your scene delegate or
-`application:openURL:options:` implementation. Parse query items with
-`NSURLComponents` instead of manually splitting strings.
+On current iOS versions, handle the callback in your scene delegate or `application:openURL:options:` implementation. Parse query items with `NSURLComponents` instead of manually splitting strings.
 
 ```swift
 func scene(_ scene: UIScene, openURLContexts urlContexts: Set<UIOpenURLContext>) {
@@ -136,9 +120,7 @@ func scene(_ scene: UIScene, openURLContexts urlContexts: Set<UIOpenURLContext>)
 - Keep using `sumupmerchant://pay/1.0`. Existing integrators rely on that path.
 - Preserve the current query parameter and callback parameter names.
 - Do not assume all callback parameters are present on older SumUp app versions.
-- If you need richer in-app payment flows, migrate to the
-  [SumUp iOS SDK](https://github.com/sumup/sumup-ios-sdk) rather than extending
-  the URL contract.
+- If you need richer in-app payment flows, migrate to the [SumUp iOS SDK](https://github.com/sumup/sumup-ios-sdk) rather than extending the URL contract.
 
 ## Community
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # SumUp iOS URL Scheme
 
-[![Documentation](https://img.shields.io/badge/docs-docs.sumup.com-0A2540)](https://docs.sumup.com)
+[![Documentation][docs-badge]](https://developer.sumup.com)
 [![CI Status](https://github.com/sumup/sumup-ios-url-scheme/actions/workflows/ci.yml/badge.svg)](https://github.com/sumup/sumup-ios-url-scheme/actions/workflows/ci.yml)
 [![License](https://img.shields.io/github/license/sumup/sumup-ios-url-scheme)](./LICENSE)
 [![Platform](https://img.shields.io/badge/platform-iOS-000000)](https://developer.apple.com/ios/)
@@ -144,3 +144,5 @@ func scene(_ scene: UIScene, openURLContexts urlContexts: Set<UIOpenURLContext>)
 
 - Questions: contact [integration@sumup.com](mailto:integration@sumup.com)
 - Bugs: [open an issue](https://github.com/sumup/sumup-ios-url-scheme/issues/new)
+
+[docs-badge]: https://img.shields.io/badge/SumUp-documentation-white.svg?logo=data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMjQiIGhlaWdodD0iMjQiIHZpZXdCb3g9IjAgMCAyNCAyNCIgZmlsbD0ibm9uZSIgY29sb3I9IndoaXRlIiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciPgogICAgPHBhdGggZD0iTTIyLjI5IDBIMS43Qy43NyAwIDAgLjc3IDAgMS43MVYyMi4zYzAgLjkzLjc3IDEuNyAxLjcxIDEuN0gyMi4zYy45NCAwIDEuNzEtLjc3IDEuNzEtMS43MVYxLjdDMjQgLjc3IDIzLjIzIDAgMjIuMjkgMFptLTcuMjIgMTguMDdhNS42MiA1LjYyIDAgMCAxLTcuNjguMjQuMzYuMzYgMCAwIDEtLjAxLS40OWw3LjQ0LTcuNDRhLjM1LjM1IDAgMCAxIC40OSAwIDUuNiA1LjYgMCAwIDEtLjI0IDcuNjlabTEuNTUtMTEuOS03LjQ0IDcuNDVhLjM1LjM1IDAgMCAxLS41IDAgNS42MSA1LjYxIDAgMCAxIDcuOS03Ljk2bC4wMy4wM2MuMTMuMTMuMTQuMzUuMDEuNDlaIiBmaWxsPSJjdXJyZW50Q29sb3IiLz4KPC9zdmc+


### PR DESCRIPTION
Rewrite the README around the stable URL-scheme contract, add a modern iOS integration checklist and callback example, and keep Objective-C helper usage documented for existing integrators.